### PR TITLE
Fixed incorrect checking of filterCollisionByTag in Fracture.cs

### DIFF
--- a/Runtime/Scripts/Fracture.cs
+++ b/Runtime/Scripts/Fracture.cs
@@ -80,7 +80,7 @@ public class Fracture : MonoBehaviour
                 // Object is unfrozen if the colliding object has the correct tag (if tag filtering is enabled)
                 // and the collision force exceeds the minimum collision force.
                 if (collisionForce > triggerOptions.minimumCollisionForce &&
-                   (!triggerOptions.filterCollisionsByTag || tagAllowed))
+                   (triggerOptions.filterCollisionsByTag && tagAllowed))
                 {
                     callbackOptions.CallOnFracture(contact.otherCollider, gameObject, contact.point);
                     this.ComputeFracture();
@@ -96,7 +96,7 @@ public class Fracture : MonoBehaviour
             // Colliding object tag must be in the set of allowed collision tags if filtering by tag is enabled
             bool tagAllowed = triggerOptions.IsTagAllowed(collider.gameObject.tag);
 
-            if (!triggerOptions.filterCollisionsByTag || tagAllowed)
+            if (triggerOptions.filterCollisionsByTag && tagAllowed)
             {
                 callbackOptions.CallOnFracture(collider, gameObject, transform.position);
                 this.ComputeFracture();


### PR DESCRIPTION
Flipped the conditional statements which were incorrectly checking filterCollisionByTag and tagAllowed, causing the inverse effect to what was intended. This means that if unchecked, Collision would always trigger the fracture, even if Trigger was the selected type.

(Was hitting my head against a wall for a while with this, so just in case someone finds the same problem where fractures would happen even if not triggered, but configured correctly in the inspector).